### PR TITLE
Fix issue #437

### DIFF
--- a/install/createKernel.py
+++ b/install/createKernel.py
@@ -426,7 +426,7 @@ class PixiedustInstall(InstallKernelSpec):
             return None
 
     def get_scala_version(self):
-        return get_scala_version_from_dir(self.scala_home)
+        return self.get_scala_version_from_dir(self.scala_home)
 
     def download_scala(self, scala_version):
         while True:


### PR DESCRIPTION
Call to get Scala version failed when specifying existing Scala install dir. Fix was noted in the issue.