### PR TITLE
Implement force load with pandas

### DIFF
--- a/pixiedust/utils/sampleData.py
+++ b/pixiedust/utils/sampleData.py
@@ -81,7 +81,7 @@ dataDefs = OrderedDict([
 @scalaGateway
 def sampleData(dataId=None, type='csv', forcePandas=False):
     global dataDefs
-    return SampleData(dataDefs,forcePandas).sampleData(dataId, type)
+    return SampleData(dataDefs, forcePandas).sampleData(dataId, type)
 
 class SampleData(object):
     env = PixiedustTemplateEnvironment()


### PR DESCRIPTION
#441.

Added kwarg `forcePandas` to force `pixiedust.sampleData` to load using pandas instead of Spark.  Default value is False.

Example usage (assume user has Spark):

```
transportation = pixiedust.sampleData(1,forcePandas=True)
print type(transportation)
```

Output:
```
Creating pandas DataFrame for 'Car performance data'. Please wait...
Loading file using 'pandas'
Successfully created pandas DataFrame for 'Car performance data'
<class 'pandas.core.frame.DataFrame'>
```

Without `forcePandas`, `pixiedust.sampleData` will simply load into a Spark DataFrame as usual:

```
transportationDefault = pixiedust.sampleData(1)
print type(transportationDefault)
```

Output:

```
Creating pySpark DataFrame for 'Car performance data'. Please wait...
Loading file using 'com.databricks.spark.csv'
Successfully created pySpark DataFrame for 'Car performance data'
<class 'pyspark.sql.dataframe.DataFrame'>
```