### PR TITLE
#367: More informative API key error messages for Mapbox/Google Maps

### DIFF
--- a/pixiedust/display/chart/renderers/google/templates/noapikey.html
+++ b/pixiedust/display/chart/renderers/google/templates/noapikey.html
@@ -1,12 +1,12 @@
 <div>
     <h2>No Google Maps API Key</h2>
     <p>
-        Some functionality of the Google maps renderer requires an API key.
+        Some functionality of the Google Maps renderer requires an API key.
     </p>
     <p>
         You can obtain an API key from the <a href="https://code.google.com/apis/console/" target="_blank">Google API Console</a>.
         After <a href="https://support.google.com/googleapi/answer/6158862?hl=en&ref_topic=7013279" target="_blank">getting the API key</a>,
-        it must be enabled for the <a href="https://console.developers.google.com/projectselector/apis/library" target="_blank">Google Maps Javascript API and the Geocoding API</a>.
+        it must be enabled for the <a href="https://console.developers.google.com/projectselector/apis/library" target="_blank">Google Maps JavaScript API and the Geocoding API</a>.
         Once enabled, you may enter the API key in the Options dialog.
     </p>
 </div>

--- a/pixiedust/display/chart/renderers/google/templates/tokenerror.html
+++ b/pixiedust/display/chart/renderers/google/templates/tokenerror.html
@@ -1,0 +1,13 @@
+<div>
+    {% if this.response.status_code != 200 %}
+    <h2>{{ this.response.status_code }} Error</h2>
+    <p>
+        Error: {{ this.response.reason }}
+    </p>
+    {% else %}
+    <h2>Google Maps API Key Error</h2>
+    <p>
+        Error: {{ this.response.json()['error_message'] }}
+    </p>
+    {% endif %}
+</div>

--- a/pixiedust/display/chart/renderers/mapbox/mapBoxMapDisplay.py
+++ b/pixiedust/display/chart/renderers/mapbox/mapBoxMapDisplay.py
@@ -24,6 +24,7 @@ import json
 import numpy
 import geojson
 import uuid
+import requests
 
 def defaultJSONEncoding(o):
     if isinstance(o, numpy.integer): 
@@ -37,10 +38,7 @@ class MapViewDisplay(MapBoxBaseDisplay):
         return True
 
     def supportsAggregation(self, handlerId):
-        return True
-
-    def getDefaultAggregation(self, handlerId):
-        return "SUM"
+        return False
 
     def supportsLegend(self, handlerId):
         return True
@@ -64,8 +62,13 @@ class MapViewDisplay(MapBoxBaseDisplay):
     
     def doRenderChart(self):
         mbtoken = self.options.get("mapboxtoken")
-        if not mbtoken or len(mbtoken)<5:
+        if not mbtoken:
             return self.renderTemplate("noaccesstoken.html")
+        else:
+            self.response = requests.get("https://api.mapbox.com/tokens/v2?access_token=" + mbtoken)
+            if (self.response.status_code == 200 and self.response.json()['code'] != 'TokenValid') \
+                    or self.response.status_code != 200:
+                return self.renderTemplate("tokenerror.html")
 
         body = self.renderMapView(mbtoken)
         if self.isStreaming:

--- a/pixiedust/display/chart/renderers/mapbox/templates/tokenerror.html
+++ b/pixiedust/display/chart/renderers/mapbox/templates/tokenerror.html
@@ -1,0 +1,13 @@
+<div>
+    {% if this.response.status_code != 200 %}
+    <h2>{{ this.response.status_code }} Error</h2>
+    <p>
+        Error: {{ this.response.reason }}
+    </p>
+    {% else %}
+    <h2>Mapbox Access Token Error</h2>
+    <p>
+        Error: {{ this.response.json()['code'] }}
+    </p>
+    {% endif %}
+</div>


### PR DESCRIPTION
Fix for #367 (API key error messages for map renderers). Also takes care of #410 (disable aggregation for map renderers)