### PR TITLE
fix CSV exports to avoid destroying the data when it contains , or "

### DIFF
--- a/pixiedust/display/download/downloadFile.py
+++ b/pixiedust/display/download/downloadFile.py
@@ -21,6 +21,17 @@ import time
 DELIMITER="@#$DELIMITER@#$"
 
 class DownloadFileHandler(Display):
+
+    # modify a string so it suitable to be exported to a CSV file
+    def csvify(self, s):
+        # replace LF/CR with space and " with ""
+        s = s.replace("\n"," ").replace("\r"," ").replace('"','""')
+        # if the string contains a , or "
+        if ',' in s or '"' in s:
+            # excape the whole string in double quotes
+            s = '"' + s + '"'
+        return s
+
     def doRender(self, handlerId):
         entity=self.entity
         self.addProfilingTime = False
@@ -95,7 +106,7 @@ class DownloadFileHandler(Display):
             print(DELIMITER)
             print(reduce(lambda s,f: s + ("," if s!="" else "") + f.name, schema.fields,""))                
             for row in entity.take(doDownloadCount):
-                print(reduce(lambda s,f: s+("," if s!="" else "")+self._safeString(row[f.name]), schema.fields, ""))
+                print(reduce(lambda s,f: s+("," if s!="" else "")+self.csvify(self._safeString(row[f.name])), schema.fields, ""))
             print(DELIMITER)
         elif doDownload == "json":
             print(DELIMITER)


### PR DESCRIPTION
fixes issue #566.

To reproduce:

```python
import pandas
d = {'col1': [1, 2,4,6], 'col2': [3, 4,5,7], 'col3': ['hello', 'hello, world', 'Hello "John"', 'Hello\n"John, Smith"']}
df = pandas.DataFrame(data=d)
display(df)
```

then use the Pixiedust widget to export a CSV.

Before this pull request you got:

```
col1,col2,col3
1,3,hello
2,4,hello, world
4,5,Hello "John"
6,7,Hello
"John, Smith"
```

Now you get:

```
col1,col2,col3
1,3,hello
2,4,"hello, world"
4,5,"Hello ""John"""
6,7,"Hello ""John, Smith"""
```

which imports into spreadsheets properly.
