### PR TITLE
used base64 encoding to get data into the iframe - fixes issue #461

### DIFF
--- a/pixiedust/display/chart/renderers/mapbox/templates/iframesrcdoc.html
+++ b/pixiedust/display/chart/renderers/mapbox/templates/iframesrcdoc.html
@@ -49,7 +49,7 @@
   }();
   {%endif%}
 </script>
-<iframe id="mapframe{{prefix}}" style='width:{{prefwidth}}px;height:{{prefheight}}px' srcdoc='{{body|btoa}}' onload="iframeLoaded(this)"></iframe>
+<iframe id="mapframe{{prefix}}" style='width:{{prefwidth}}px;height:{{prefheight}}px' srcdoc='' onload="iframeLoaded(this)"></iframe>
 <script>
   var iframe = document.getElementById('mapframe{{prefix}}');
   iframe.setAttribute('srcdoc', atob('{{body|btoa}}'));

--- a/pixiedust/display/chart/renderers/mapbox/templates/iframesrcdoc.html
+++ b/pixiedust/display/chart/renderers/mapbox/templates/iframesrcdoc.html
@@ -49,7 +49,11 @@
   }();
   {%endif%}
 </script>
-<iframe id="mapframe{{prefix}}" style='width:{{prefwidth}}px;height:{{prefheight}}px' srcdoc='{{body|oneline|replace("'","\\'")}}' onload="iframeLoaded(this)"></iframe>
+<iframe id="mapframe{{prefix}}" style='width:{{prefwidth}}px;height:{{prefheight}}px' srcdoc='{{body|btoa}}' onload="iframeLoaded(this)"></iframe>
+<script>
+  var iframe = document.getElementById('mapframe{{prefix}}');
+  iframe.setAttribute('srcdoc', atob('{{body|btoa}}'));
+</script>
 {%if this.isStreaming%}
 <div pd_refresh_rate="{{this.options.get('refresh', 1000)}}">
     <pd_script>

--- a/pixiedust/utils/template.py
+++ b/pixiedust/utils/template.py
@@ -84,6 +84,7 @@ class PixiedustTemplateEnvironment(object):
         self.env.filters['removeJSComments']=lambda s: self.removeJSComments(s)
         self.env.filters['htmlAttribute']=lambda s: self.attribute(s)
         self.env.filters['jsonify'] = json.dumps
+        self.env.filters['btoa'] = lambda s: base64.b64encode(s)
 
     def removeJSComments(self, s):
         s = re.sub(re.compile("/\*.*?\*/",re.DOTALL ) ,"" ,s)


### PR DESCRIPTION
When we render a map, we create a whole page of HTML and then convert into a single line and shove it into an `iframe`. This easily breaks with odd characters or quotes etc. 

I fixed this by base64-encoding the string to avoid doing any manipulation on the HTML. The base64 string is unpacked on the client side and injected into the iframe. 

see issue #461 for the full write-up