### PR TITLE
debugger enhancements

### DIFF
--- a/pixiedust/apps/debugger/templates/mainScreen.html
+++ b/pixiedust/apps/debugger/templates/mainScreen.html
@@ -89,12 +89,23 @@
     .pd-debugger-gutter .error-line {
         background-color: #fdaeb7;
     }
-    .pd-debugger-gutter .breakpoint-line code::before {
+    .pd-debugger-gutter .fa-bug {
         color: crimson;
-        content: " \f188";
-        font: normal normal normal 12px/1 FontAwesome;
+        cursor: pointer;
+        display: inline;
+        font-size: 12px;
         padding-right: 5px;
-        visibility: initial;
+        opacity: 0;
+    }
+    .pd-debugger-gutter .fa-bug:hover {
+        color: crimson;
+        opacity: 0.45;
+    }
+    .pd-debugger-gutter .breakpoint-line .fa-bug {
+        opacity: 1;
+    }
+    .pd-debugger-gutter .breakpoint-line .fa-bug:hover {
+        opacity: 0.75;
     }
     .pd-debugger-gutter > div > code:hover {
         visibility: hidden;
@@ -210,8 +221,8 @@
                     parts[2] = parts[2].replace(/>>/, '')
                     rowclass += ' error-line'
                 }
-                gutter.push('<div class="' + rowclass + '"><code title="Continue execution until a line with a number greater or equal to this line number is reached.">' + parts[1].trim() + '</code></div>')
-                source.push('<div class="' + rowclass + '"><code>' + (parts[2].substring(1).replace("<", "&lt;") || '&nbsp;') + '</code></div>')
+                gutter.push('<div data-lineno="' + parts[1].trim() + '" class="' + rowclass + '"><i class="fa fa-bug breakpointgutter"></i><code title="Continue execution until a line with a number greater or equal to this line number is reached.">' + parts[1].trim() + '</code></div>')
+                source.push('<div data-lineno="' + parts[1].trim() + '" class="' + rowclass + '"><code>' + (parts[2].substring(1).replace("<", "&lt;") || '&nbsp;') + '</code></div>')
             }
         }
         for (var j=gutter.length; j<5; j++) {
@@ -227,16 +238,22 @@
             $('#code{{prefix}} .pd-debugger-gutter code').on('click', function () {
                 var lineno = $(this).text()
                 $('#btn-unt-{{prefix}}')
-                    .attr('pd_target', "debugger_refresh")
                     .attr('pd_options', 'send_input_reply=unt ' + lineno)
-                $('#btn-unt-{{prefix}}').click()
+                    .click()
+            })
+            $('#code{{prefix}} .pd-debugger-gutter .breakpointgutter').on('click', function () {
+                var lineno = $(this).parent().attr('data-lineno')
+                var cmd = $(this).parent().hasClass('breakpoint-line') ? 'cl ' : 'b '
+                $('#btn-unt-{{prefix}}')
+                    .attr('pd_options', 'send_input_reply=' + cmd + lineno)
+                    .click()
             })
         }, 250)
         return '<div class="pd-debugger-code"><div class="pd-debugger-gutter">' + 
                 gutter.join('') + 
                 '</div><div class="pd-debugger-source">' + 
                 source.join('')  + 
-                '</div><button style="display:none" id="btn-unt-{{prefix}}"></button></div>'
+                '</div><button style="display:none" id="btn-unt-{{prefix}}" pd_target="debugger_refresh"></button></div>'
     }
     var truncate = function(s){
         if (s.length > 20){

--- a/pixiedust/apps/debugger/templates/mainScreen.html
+++ b/pixiedust/apps/debugger/templates/mainScreen.html
@@ -98,14 +98,10 @@
         opacity: 0;
     }
     .pd-debugger-gutter .fa-bug:hover {
-        color: crimson;
         opacity: 0.45;
     }
     .pd-debugger-gutter .breakpoint-line .fa-bug {
         opacity: 1;
-    }
-    .pd-debugger-gutter .breakpoint-line .fa-bug:hover {
-        opacity: 0.75;
     }
     .pd-debugger-gutter > div > code:hover {
         visibility: hidden;
@@ -199,6 +195,12 @@
         border-radius: 0;
         font-size: 14px;
     }
+    .pd-remove-bp {
+        border: 0 none;
+        background-color: transparent;
+        color: red;
+        opacity: 0.85;
+    }
 </style>
 <script>
     var formatCodeOutput = function(output) {
@@ -241,11 +243,10 @@
                     .attr('pd_options', 'send_input_reply=unt ' + lineno)
                     .click()
             })
-            $('#code{{prefix}} .pd-debugger-gutter .breakpointgutter').on('click', function () {
+            $('#code{{prefix}} .pd-debugger-gutter :not(.breakpoint-line) .breakpointgutter').on('click', function () {
                 var lineno = $(this).parent().attr('data-lineno')
-                var cmd = $(this).parent().hasClass('breakpoint-line') ? 'cl ' : 'b '
                 $('#btn-unt-{{prefix}}')
-                    .attr('pd_options', 'send_input_reply=' + cmd + lineno)
+                    .attr('pd_options', 'send_input_reply=b ' + lineno)
                     .click()
             })
         }, 250)
@@ -381,6 +382,7 @@
                         var lines = output.split('\n');
                         var html = '<table width="100%">';
                         var colsCount = 0;
+                        var btn = ''
                         for (var i in lines){
                             var parts = lines[i].split(/\s+/);
                             if (i == 0){
@@ -400,8 +402,9 @@
                                 if (parts.length > colsCount){
                                     parts = parts.slice(0, colsCount-1).concat( parts.slice(colsCount-1).join(" "));
                                 }
-                                parts.forEach(function(part){
-                                    html += "<td>" + part.replace("<", "&lt;") + "</td>";
+                                parts.forEach(function(part, idx){
+                                    btn = idx > 0 ? '' : ('<button title="Clear breakpoint" class="pd-remove-bp" pd_target="debugger_refresh" pd_options="send_input_reply=clear ' + part + '"><i class="fa fa-trash-o"></i></button>')
+                                    html += "<td>" + btn + part.replace("<", "&lt;") + "</td>";
                                 });
                                 html += "</tr>";
                                 if ( i == lines.length - 1){

--- a/pixiedust/apps/debugger/templates/mainScreen.html
+++ b/pixiedust/apps/debugger/templates/mainScreen.html
@@ -203,6 +203,12 @@
     }
 </style>
 <script>
+    var triggerInputOnEnter = function(btnId, elt, evt) {
+        if ((evt.keyCode ? evt.keyCode : evt.which) === 13) {
+            $('#' + btnId).click()
+            $(elt).val('')
+        }
+    }
     var formatCodeOutput = function(output) {
         var lines = output.split(/\r?\n/)
         var gutter = []
@@ -364,9 +370,10 @@
                 <div class="col-sm-12">
                     <i class="fa fa-angle-right fa-2x"></i>
                     <div class="input-group">
-                        <input id="evaluate_input_{{prefix}}" type="text" class="form-control" placeholder="Enter an expression" style="border-radius: 0;">
+                        <input id="evaluate_input_{{prefix}}" type="text" class="form-control" onkeypress="triggerInputOnEnter('evaluate_btn_{{prefix}}', this, event)"
+                            placeholder="Enter an expression" style="border-radius: 0;">
                         <span class="input-group-btn">
-                            <button class="btn btn-primary" type="button"
+                            <button class="btn btn-primary" type="button" id="evaluate_btn_{{prefix}}"
                                 title="Evaluate the expression in the current context and print its value"
                                 pd_target="evaluate_{{prefix}}"
                                 pd_options="send_input_reply=pp $val(evaluate_input_{{prefix}})">Run</button>
@@ -421,9 +428,10 @@
                 <div class="col-sm-12">
                     <i class="fa fa-angle-right fa-2x"></i>
                     <div class="input-group">
-                        <input id="breakpoints_input_{{prefix}}" type="text" class="form-control" placeholder="Enter a breakpoint (line no or method)" style="border-radius: 0;">
+                        <input id="breakpoints_input_{{prefix}}" type="text" class="form-control" onkeypress="triggerInputOnEnter('breakpoints_btn_{{prefix}}', this, event)"
+                            placeholder="Enter a breakpoint (line no or method)" style="border-radius: 0;">
                         <span class="input-group-btn">
-                            <button class="btn btn-primary" type="button"
+                            <button class="btn btn-primary" type="button" id="breakpoints_btn_{{prefix}}"
                                 title="Add a breakpoint to the module currently executed"
                                 pd_target="debugger_refresh"
                                 pd_options="send_input_reply=break $val(breakpoints_input_{{prefix}})">Add</button>


### PR DESCRIPTION
#650 
 - breakpoints can be added by clicking on the gutter column of the code panel
 - breakpoints can be removed by click on the trash icon in the breakpoints tab
 - when typing an expression to evaluate, `Enter` can be pressed to trigger the evaluation
 - when typing in a breakpoint to enable, `Enter` can be pressed to set the breakpoint