### PR TITLE
Fixed hex decoding issue with Python 3

### DIFF
--- a/pixiedust/display/chart/renderers/mapbox/mapBoxMapDisplay.py
+++ b/pixiedust/display/chart/renderers/mapbox/mapBoxMapDisplay.py
@@ -334,7 +334,8 @@ class MapViewDisplay(MapBoxBaseDisplay):
 
     def _getMonochromeLight(self, customBaseColor, nColors):
         # HEX -> RGB
-        customBaseColorRGB = tuple(map(ord,customBaseColor[1:].decode('hex')))
+        customBaseColor = customBaseColor.lstrip("#")
+        customBaseColorRGB = tuple(int(customBaseColor[i:i+2], 16) for i in (0, 2 ,4))
         # RGB -> HSV
         customBaseColorHSV = colorsys.rgb_to_hsv(customBaseColorRGB[0]/float(255), customBaseColorRGB[1]/float(255), customBaseColorRGB[2]/float(255))
         h, s, v = customBaseColorHSV
@@ -350,7 +351,8 @@ class MapViewDisplay(MapBoxBaseDisplay):
 
     def _getMonochromeDark(self, customBaseColor, nColors):
         # HEX -> RGB
-        customBaseColorRGB = tuple(map(ord,customBaseColor[1:].decode('hex')))
+        customBaseColor = customBaseColor.lstrip("#")
+        customBaseColorRGB = tuple(int(customBaseColor[i:i+2], 16) for i in (0, 2 ,4))
         # RGB -> HSV
         customBaseColorHSV = colorsys.rgb_to_hsv(customBaseColorRGB[0]/float(255), customBaseColorRGB[1]/float(255), customBaseColorRGB[2]/float(255))
         h, s, v = customBaseColorHSV


### PR DESCRIPTION
@DanielManning: Can you please review this fix for Python 3. 
The decode method is not available in Python 3, I replace the hex decoding with a plain algorithm